### PR TITLE
 merge queryparams instead of params

### DIFF
--- a/App/Stores/UserStore.js
+++ b/App/Stores/UserStore.js
@@ -25,7 +25,7 @@ var store = createStore({
 
     switch(action.actionType) {
       case UserConstants.FACEBOOK_SIGN_IN:
-        _user = Immutable.fromJS(merge(action.response, action.params));
+        _user = Immutable.fromJS(merge(action.response, action.queryParams));
         store.emitChange(action);
         break;
     }


### PR DESCRIPTION
@brentvatne  think this is a typo.

payload that comes back from fb looks like this:

queryParams, not params

![image](https://cloud.githubusercontent.com/assets/548027/7027351/fe4ab206-dd1c-11e4-86a2-c07621f2d92e.png)
